### PR TITLE
fix: remove known percent also for sub-ingredients

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ Once Recipe Estimator runs in your dev environment, you can use the recipe_estim
 
 # Usage
 
+## Installation
+
+## Python environment
+
+This is using Python3.
+
+Create a virtualenv.
+```
+python -m venv venv 
+```
+
+Enter virtualenv (Windows).
+```
+venv/Scripts/activate
+```
+or (Linux)
+```
+source venv/bin/activate
+```
+
+Install requirements.
+```
+pip install -r requirements.txt
+```
+
 ## Create or add to a test set the products corresponding to a search query
 
 This script is used to create a new test set by querying the Open Food Facts production (or local development) database for products matching a specific query.
@@ -81,6 +106,14 @@ Remove fields that are not needed.
 
 ```bash
 ./scripts/clean_input_test_sets.py test-sets/input/fr-1000-some-specified-popular
+```
+
+## Update the ingredients parsing of a test set
+
+This script reruns the ingredients analysis to recreate the "ingredients" structure from the textual list of ingredients (ingredients_text).
+
+```bash
+./scripts/parse_ingredients_for_input_test_sets.py test-sets/input/fr-1000-some-specified-popular
 ```
 
 ## Run a model on a test set

--- a/scripts/compute_metrics.py
+++ b/scripts/compute_metrics.py
@@ -20,12 +20,23 @@ import math
 
 round_to_n = lambda x, n: x if x == 0 else round(x, -int(math.floor(math.log10(abs(x)))) + (n - 1))
 
+def add_missing_estimates_for_parent_ingredients(ingredients):
+    # Add missing percent_estimate to parent ingredients by summing the percent_estimate of their children
+    for ingredient in ingredients:
+        if "ingredients" in ingredient:
+            add_missing_estimates_for_parent_ingredients(ingredient["ingredients"])
+            if "percent_estimate" not in ingredient:
+                ingredient["percent_estimate"] = sum([sub_ingredient["percent_estimate"] for sub_ingredient in ingredient["ingredients"]])
+
 def compare_input_ingredients_to_resulting_ingredients(input_ingredients, resulting_ingredients, ingredients_stats, products_ingredients_csv_writer, test_name):
     # Compute difference metrics for each ingredient and nested sub ingredient comparing the input percent to the resulting percent_estimate
 
     total_difference = 0
     total_specified_input_percent = 0
     number_of_ingredients_without_ciqual_code = 0
+
+    # add missing percent_estimate to parent ingredients by summing the percent_estimate of their children
+    add_missing_estimates_for_parent_ingredients(resulting_ingredients)
 
     for i, input_ingredient in enumerate(input_ingredients):
         resulting_ingredient = resulting_ingredients[i]

--- a/scripts/parse_ingredients_for_input_test_sets.py
+++ b/scripts/parse_ingredients_for_input_test_sets.py
@@ -42,9 +42,7 @@ for test_set_path in sys.argv[1:]:
         request_data = {
             #"services": ["parse_ingredients_text", "extend_ingredients", "estimate_ingredients_percent"],
             "services": ["parse_ingredients_text", "extend_ingredients"],
-            "fields": [""],
-            "lc": "fr",
-            "tags_lc": "fr",
+            "fields": ["all"],
             "product": product
         }
         response = requests.post(product_opener_api_url, json=request_data)

--- a/scripts/run_model_on_input_test_sets.py
+++ b/scripts/run_model_on_input_test_sets.py
@@ -36,6 +36,9 @@ def remove_percent_fields(ingredients):
         for field in fields_to_remove:
             if field in ingredient:
                 del ingredient[field]
+        # recursively remove percent fields from sub-ingredients
+        if "ingredients" in ingredient:
+            ingredient["ingredients"] = remove_percent_fields(ingredient["ingredients"])
     return ingredients
 
 # Check input parameters (existing model executable, and specified results path + at least 1 input test set), otherwise print usage


### PR DESCRIPTION
fixed bug spotted by @very-smartin : known "percent" were not removed for sub-ingredients.

as a result, metrics for product opener were over estimated.

recipe-estimator metrics do not change, as it is not using known percent. (we should add it).